### PR TITLE
Linking directly to the csv

### DIFF
--- a/wtf.py
+++ b/wtf.py
@@ -65,7 +65,7 @@ def slack():
     except KeyError:
         response = """
         Entry for '{}' not found! Acronyms may be added at
-        https://github.com/department-of-veterans-affairs/acronyms
+        https://github.com/department-of-veterans-affairs/acronyms/acronyms.csv
         """.format(req['text'])
 
     return make_response(response)


### PR DESCRIPTION
The bot "not found" error message links to the root of the repo and it seems like hitting the csv directly will help people add to the definitions